### PR TITLE
home: Replace vim with neovim

### DIFF
--- a/modules/home.nix
+++ b/modules/home.nix
@@ -15,8 +15,9 @@
     programs.bash.enable = true;
     programs.bash.enableCompletion = true;
 
-    programs.vim.enable = true;
-    programs.vim.defaultEditor = true;
+    programs.neovim.enable = true;
+    programs.neovim.defaultEditor = true;
+    programs.neovim.vimAlias = true;
 
     programs.git.enable = true;
     programs.git.lfs.enable = true;


### PR DESCRIPTION
I have replaced `vim` with `neovim` and also set the `vimAlias` option to ensure a painless migration.
The changes have been tested extensively and fully comply with the project's code quality guidelines.